### PR TITLE
Trello: [iOS/RN] Tidepool Mobile should use `service` for `origin.typ…

### DIFF
--- a/TidepoolMobile/DataModel/HealthKit/HealthKitUploadType.swift
+++ b/TidepoolMobile/DataModel/HealthKit/HealthKitUploadType.swift
@@ -97,7 +97,7 @@ class HealthKitUploadType {
 
         if let userEntered = sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool {
             if userEntered {
-                origin["type"] = "manual" as AnyObject
+                origin["type"] = "service" as AnyObject
             }
         }
         

--- a/TidepoolMobile/DataModel/HealthKit/HealthKitUploadTypeWorkout.swift
+++ b/TidepoolMobile/DataModel/HealthKit/HealthKitUploadTypeWorkout.swift
@@ -263,8 +263,8 @@ class HealthKitUploadTypeWorkout: HealthKitUploadType {
             return ("Wrestling", "wrestling")
         case .yoga:
             return ("Yoga", "yoga")
-        //default:
-        //    return ("Other Activity", "other")
+        default:
+            return ("Other Activity", "other")
         }
     }
 

--- a/TidepoolMobile/Info.plist
+++ b/TidepoolMobile/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.10</string>
+	<string>2.1.11</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
…e` field rather than `manual.

Trello: [iOS] Crashes during Sync to Health from a new Workout type.
Bump build to 2.1.11.