### PR TITLE
Fix Trello: "[iOS] Tidepool Mobile new note created during first time…

### DIFF
--- a/TidepoolMobile/ViewControllers/EventAddEditViewController.swift
+++ b/TidepoolMobile/ViewControllers/EventAddEditViewController.swift
@@ -493,6 +493,8 @@ class EventAddEditViewController: BaseUIViewController, UITextViewDelegate {
         if (messageBox.text != defaultMessage && !messageBox.text.isEmpty) {
             APIConnector.connector().trackMetric("Clicked Post Note")
             
+            self.note.createdtime = Date()
+
             // if messageBox has text (not default message or empty) --> set the note to have values
             self.note.messagetext = self.messageBox.text
             self.note.groupid = self.group.userid

--- a/TidepoolMobile/ViewControllers/EventListViewController.swift
+++ b/TidepoolMobile/ViewControllers/EventListViewController.swift
@@ -50,6 +50,7 @@ class EventListViewController: BaseUIViewController, ENSideMenuDelegate, NoteAPI
     fileprivate var sortedNotes: [NoteInEventListTable] = []
     fileprivate var filteredNotes: [NoteInEventListTable] = []
     fileprivate var filterString = ""
+    var justPerformedUnwindToDoneAddNote = false
     // Fetch all notes for now...
     var loadingNotes = false
     
@@ -198,10 +199,11 @@ class EventListViewController: BaseUIViewController, ENSideMenuDelegate, NoteAPI
             sideMenu.allowPanGesture = true
        }
 
-        if sortedNotes.isEmpty || eventListNeedsUpdate {
+        if (sortedNotes.isEmpty || eventListNeedsUpdate) && !justPerformedUnwindToDoneAddNote {
             eventListNeedsUpdate = false
             loadNotes()
         }
+        justPerformedUnwindToDoneAddNote = false
 
         // periodically check for authentication issues in case we need to force a new login
         let appDelegate = UIApplication.shared.delegate as? AppDelegate
@@ -672,6 +674,7 @@ class EventListViewController: BaseUIViewController, ENSideMenuDelegate, NoteAPI
         } else {
             DDLogInfo("Unknown segue source!")
         }
+        justPerformedUnwindToDoneAddNote = true
     }
 
     // Save button from edit comment.


### PR DESCRIPTION
… tooltip prompting user to "Add note" doesn't open because of prompt to "Tap a note to open" it."

- Remember that we are segueing to unwindToDoneAddNote and avoid reloading notes in that case
- Update createdtime for new note at time of post